### PR TITLE
Fix strange gzip body

### DIFF
--- a/src/main/java/com/wego/httpcache/services/impl/AsyncHttpCacheServiceImpl.java
+++ b/src/main/java/com/wego/httpcache/services/impl/AsyncHttpCacheServiceImpl.java
@@ -20,7 +20,6 @@ public class AsyncHttpCacheServiceImpl implements AsyncHttpCacheService {
   @Inject
   private CachedResponseService cachedResponseService;
 
-  @Inject
   private AsyncHttpClient asyncHttpClient;
 
   private long ttl;


### PR DESCRIPTION
### Purpose
Fix strange gzip body

There a strange behaviour of AsyncHttpClient in AsyncHttpCacheServices when sometime it returns Gzip body instead of Json object although `content-type` header is set to `application/json`.

### Approach
Remove redundant `@Inject` annotations for AsyncHttpClient because with annotations it will create another AsyncHttpClient instance instead of the one we set in constructor.

