### PR TITLE
Add Service name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ group 'com.wego'
 version '1.0.1'
 
 apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'checkstyle'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -9,10 +11,6 @@ targetCompatibility = '1.8'
 task wrapper(type: Wrapper) {
     gradleVersion = '2.8'
 }
-
-apply plugin: 'maven'
-
-apply plugin: 'checkstyle'
 
 repositories {
     mavenCentral()

--- a/src/test/java/com/wego/httpcache/services/impl/TestAsyncHttpCacheServiceImpl.java
+++ b/src/test/java/com/wego/httpcache/services/impl/TestAsyncHttpCacheServiceImpl.java
@@ -44,6 +44,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TestAsyncHttpCacheServiceImpl {
 
+  private final static String SERVICE_NAME = "Service Name";
+
   private static long CACHING_TTL = 60;
   @Rule
   public WireMockRule wireMockRule = new WireMockRule(8089);
@@ -53,7 +55,7 @@ public class TestAsyncHttpCacheServiceImpl {
 
   @InjectMocks
   private AsyncHttpCacheService asyncHttpCacheService =
-      new AsyncHttpCacheServiceImpl(asyncHttpClient, CACHING_TTL);
+      new AsyncHttpCacheServiceImpl(SERVICE_NAME, asyncHttpClient, CACHING_TTL);
 
   @Mock
   private CachedResponseService cachedResponseService;
@@ -235,6 +237,7 @@ public class TestAsyncHttpCacheServiceImpl {
             .collect(Collectors.toList());
 
     assertThat(Sets.newHashSet(responseIds).size()).isEqualTo(13);
+    assertThat(responseIds.get(0)).startsWith(SERVICE_NAME);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Add serviceName to AsyncHttpCacheService so that we can differentiate one from other. Also add serviceName as prefix in responseId, it's helpful when we want to delete cache by serviceName of only one AsyncHttpCacheService instance, not all.